### PR TITLE
Max fail count

### DIFF
--- a/scripts/run_unit_tests
+++ b/scripts/run_unit_tests
@@ -1,7 +1,8 @@
 #!/bin/sh
 set -e
+set -o xtrace
 export PYTHONPATH=.
 # Set all env vars
 export $(cat tests/test.env | xargs)
-path=${1:-"tests/unit"}
+path=${@:-"tests/unit"}
 poetry run pytest -vv $path

--- a/src/index_runner/event_loop.py
+++ b/src/index_runner/event_loop.py
@@ -22,7 +22,8 @@ def start_loop(
         on_failure: Callable[[Message, Exception], None] = lambda msg, e: None,
         on_config_update: Callable[[], None] = lambda: None,
         logger: logging.Logger = logging.getLogger('IR'),
-        return_on_empty: bool = False):
+        return_on_empty: bool = False,
+        timeout: float = 0.5):
     """
     Run the indexer event loop.
 
@@ -42,7 +43,7 @@ def start_loop(
     # Failure count for the current offset
     fail_count = 0
     while True:
-        msg = consumer.poll(timeout=0.5)
+        msg = consumer.poll(timeout=timeout)
         if msg is None:
             logger.info('Message empty')
             if return_on_empty:

--- a/src/index_runner/event_loop.py
+++ b/src/index_runner/event_loop.py
@@ -86,6 +86,7 @@ def start_loop(
             if fail_count > config()['max_handler_failures']:
                 logger.info(f"Reached max failure count of {fail_count}. Moving on.")
                 consumer.commit()
+                fail_count = 0
             else:
                 fail_count += 1
 

--- a/src/index_runner/event_loop.py
+++ b/src/index_runner/event_loop.py
@@ -43,7 +43,6 @@ def start_loop(
     fail_count = 0
     while True:
         msg = consumer.poll(timeout=0.5)
-        logger.info('Received message.')
         if msg is None:
             logger.info('Message empty')
             if return_on_empty:

--- a/src/index_runner/event_loop.py
+++ b/src/index_runner/event_loop.py
@@ -5,7 +5,6 @@ from confluent_kafka import Consumer, KafkaError
 from typing import Callable, Dict, Any
 import json
 import logging
-import requests
 import time
 import traceback
 
@@ -22,7 +21,8 @@ def start_loop(
         on_success: Callable[[Message], None] = lambda msg: None,
         on_failure: Callable[[Message, Exception], None] = lambda msg, e: None,
         on_config_update: Callable[[], None] = lambda: None,
-        logger: logging.Logger = logging.getLogger('IR')):
+        logger: logging.Logger = logging.getLogger('IR'),
+        return_on_empty: bool = False):
     """
     Run the indexer event loop.
 
@@ -35,26 +35,25 @@ def start_loop(
             exception. A noop by default.
         on_config_update: called when the configuration has been updated.
         logger: a logger to use for logging events. By default a standard logger for 'IR'.
+        return_on_empty: stop the loop when we receive an empty message. Helps with testing.
     """
     # Used for re-fetching the configuration with a throttle
     last_updated_minute = int(time.time() / 60)
-    if not config()['global_config_url']:
-        config_tag = _fetch_latest_config_tag()
     # Failure count for the current offset
     fail_count = 0
     while True:
         msg = consumer.poll(timeout=0.5)
+        logger.info('Received message.')
         if msg is None:
+            logger.info('Message empty')
+            if return_on_empty:
+                return
             continue
         curr_min = int(time.time() / 60)
-        if not config()['global_config_url'] and curr_min > last_updated_minute:
-            # Check for configuration updates
-            latest_config_tag = _fetch_latest_config_tag()
+        if curr_min > last_updated_minute:
+            # Reload the configuration
+            config(force_reload=True)
             last_updated_minute = curr_min
-            if config_tag is not None and latest_config_tag != config_tag:
-                config(force_reload=True)
-                config_tag = latest_config_tag
-                on_config_update()
         if msg.error():
             if msg.error().code() == KafkaError._PARTITION_EOF:
                 logger.info('End of stream.')
@@ -63,53 +62,30 @@ def start_loop(
             continue
         val = msg.value().decode('utf-8')
         try:
-            msg = json.loads(val)
+            val_json = json.loads(val)
         except ValueError as err:
             logger.error(f'JSON parsing error: {err}')
             logger.error(f'Message content: {val}')
             consumer.commit()
             continue
-        logger.info(f'Received event: {msg}')
+        logger.info(f'Received event: {val_json}')
         start = time.time()
         try:
-            message_handler(msg)
-            # Move the offset for our partition
-            consumer.commit()
-            on_success(msg)
-            fail_count = 0
-            logger.info(f"Handled {msg['evtype']} message in {time.time() - start}s")
+            message_handler(val_json)
         except Exception as err:
             logger.error(f'Error processing message: {err.__class__.__name__} {err}')
             logger.error(traceback.format_exc())
             # Save this error and message to a topic in Elasticsearch
-            on_failure(msg, err)
-            if fail_count > config()['max_handler_failures']:
+            on_failure(val_json, err)
+            fail_count += 1
+            logger.info(f"We've had {fail_count} failures so far")
+            if fail_count >= config()['max_handler_failures']:
                 logger.info(f"Reached max failure count of {fail_count}. Moving on.")
                 consumer.commit()
                 fail_count = 0
-            else:
-                fail_count += 1
-
-
-# might make sense to move this into the config module
-def _fetch_latest_config_tag():
-    """
-    Using the Github release API, check for a new version of the config.
-    https://developer.github.com/v3/repos/releases/
-    """
-    github_release_url = config()['github_release_url']
-    if config()['github_token']:
-        headers = {'Authorization': f"token {config()['github_token']}"}
-    else:
-        headers = {}
-    try:
-        resp = requests.get(url=github_release_url, headers=headers)
-    except Exception as err:
-        logging.error(f"Unable to fetch indexer config from github: {err}")
-        # Ignore any error and continue; try the fetch again later
-        return None
-    if not resp.ok:
-        logging.error(f"Unable to fetch indexer config from github: {resp.text}")
-        return None
-    data = resp.json()
-    return data['tag_name']
+            continue
+        # Move the offset for our partition
+        consumer.commit()
+        on_success(val_json)
+        fail_count = 0
+        logger.info(f"Handled {val_json['evtype']} message in {time.time() - start}s")

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -130,6 +130,7 @@ class Config:
             'generic_replica_count': os.environ.get('GENERIC_REPLICA_COUNT', 1),
             'skip_types': _get_comma_delimited_env('SKIP_TYPES'),
             'allow_types': _get_comma_delimited_env('ALLOW_TYPES'),
+            'max_handler_failures': int(os.environ.get('MAX_HANDLER_FAILURES', 3)),
         }
 
     def __getitem__(self, key):

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -34,5 +34,5 @@ def init_logger(logger: logging.Logger):
     stdout_handler = logging.StreamHandler(sys.stdout)
     stdout_handler.setFormatter(formatter)
     logger.addHandler(stdout_handler)
-    logger.info(f'Logger and level: {logger}')
+    print(f'Logger and level: {logger}')
     logger.info(f'Logging to file: {log_path}')

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -36,3 +36,6 @@ def init_logger(logger: logging.Logger):
     logger.addHandler(stdout_handler)
     print(f'Logger and level: {logger}')
     logger.info(f'Logging to file: {log_path}')
+
+
+logger = init_logger(logging.getLogger('IR'))

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -36,6 +36,7 @@ def init_logger(logger: logging.Logger):
     logger.addHandler(stdout_handler)
     print(f'Logger and level: {logger}')
     logger.info(f'Logging to file: {log_path}')
+    return logger
 
 
 logger = init_logger(logging.getLogger('IR'))

--- a/tests/unit/index_runner/helpers.py
+++ b/tests/unit/index_runner/helpers.py
@@ -1,0 +1,48 @@
+from typing import List
+import queue
+import time
+
+
+class MockMessage:
+    """Mock Kafka message returned in the mock consumer"""
+
+    def __init__(self, msg: str = '{}'):
+        self.msg = msg
+
+    def error(self):
+        return None
+
+    def value(self):
+        return self.msg.encode()
+
+
+class MockConsumer:
+    """Mock Kafka consumer for testing the event loop without needing Kafka itself."""
+
+    def __init__(self, topics: List[str]):
+        self.msg_queue = queue.Queue()
+        # Track the last message polled
+        self.msg_popped = None
+
+    def poll(self, timeout: float):
+        if self.msg_popped is not None:
+            # Last message not committed; resend it
+            return self.msg_popped
+        if self.msg_queue.empty():
+            # No new messages; wait `timeout` seconds
+            time.sleep(timeout)
+            return None
+        else:
+            # Send the next message
+            self.msg_popped = self.msg_queue.get()
+            return self.msg_popped
+
+    def commit(self):
+        """Our fake 'commit' is to clear out the "msg_popped" field, so we do
+        not resend that message and move on to the rest of the queue."""
+        self.msg_popped = None
+
+    def produce_test(self, msg: str):
+        """Push a message to the queue for testing purposes. Most likely you
+        want to call this before starting the event loop"""
+        self.msg_queue.put(MockMessage())

--- a/tests/unit/index_runner/test_event_loop.py
+++ b/tests/unit/index_runner/test_event_loop.py
@@ -1,12 +1,6 @@
-from src.utils.logger import init_logger
-import logging
-
 from src.utils.config import config
 from src.index_runner.event_loop import start_loop
 from tests.unit.index_runner.helpers import MockConsumer
-
-logger = logging.getLogger('IR')
-init_logger(logger)
 
 
 def test_retry_count():

--- a/tests/unit/index_runner/test_event_loop.py
+++ b/tests/unit/index_runner/test_event_loop.py
@@ -1,0 +1,24 @@
+from src.utils.logger import init_logger
+import logging
+
+from src.utils.config import config
+from src.index_runner.event_loop import start_loop
+from tests.unit.index_runner.helpers import MockConsumer
+
+logger = logging.getLogger('IR')
+init_logger(logger)
+
+
+def test_retry_count():
+    """Test that our handler function that always throws will get called the
+    right amount of times before getting skipped."""
+    call_count = 0
+    consumer = MockConsumer([])
+
+    def handler_raise(message):
+        nonlocal call_count
+        call_count += 1
+        raise RuntimeError('Test error')
+    consumer.produce_test('{}')
+    start_loop(consumer, handler_raise, return_on_empty=True)
+    assert call_count == config()['max_handler_failures']

--- a/tests/unit/index_runner/test_event_loop.py
+++ b/tests/unit/index_runner/test_event_loop.py
@@ -14,5 +14,5 @@ def test_retry_count():
         call_count += 1
         raise RuntimeError('Test error')
     consumer.produce_test('{}')
-    start_loop(consumer, handler_raise, return_on_empty=True)
+    start_loop(consumer, handler_raise, return_on_empty=True, timeout=0)
     assert call_count == config()['max_handler_failures']


### PR DESCRIPTION
Added a configurable failure retry counter in the event loop

Added a MockConsumer class which creates a simple and fake kafka consumer object with methods for `poll`, `commit`, etc.

Removed the code to fetch the latest config release, because all we do now is re-fetch the config from the same URL.

Addresses #126 