### PR TITLE
Index the static narrative info

### DIFF
--- a/spec/config.yaml
+++ b/spec/config.yaml
@@ -194,6 +194,8 @@ mappings:
           desc: {type: text, copy_to: agg_fields}
           cell_type: {type: keyword}
       total_cells: {type: short}
+      static_narrative_ref: {type: keyword}
+      static_narrative_saved: {type: date}
 
   "reads_1":
     global_mappings: [ws_auth, ws_object]

--- a/src/index_runner/es_indexers/narrative.py
+++ b/src/index_runner/es_indexers/narrative.py
@@ -59,6 +59,8 @@ def index_narrative(obj_data, ws_info, obj_data_v1):
             'cells': index_cells,
             'creator': creator,
             'total_cells': len(raw_cells),
+            'static_narrative_saved': ws_metadata.get('static_narrative_saved'),
+            'static_narrative_ref': ws_metadata.get('static_narrative'),
         },
         'index': _NARRATIVE_INDEX_NAME,
         'id': f'{_NAMESPACE}::{ws_id}:{obj_id}',

--- a/tests/test_data/narrative_wsinfo_narratorial.json
+++ b/tests/test_data/narrative_wsinfo_narratorial.json
@@ -15,6 +15,7 @@
         "narrative": "1",
         "data_palette_id": "2",
         "narrative_nice_name": "Test fiesta",
-        "cell_count": "3"
+        "static_narrative_saved": "1597187531703",
+        "static_narrative": "/33500/56/"
     }
 ]

--- a/tests/test_data/narrative_wsinfo_valid.json
+++ b/tests/test_data/narrative_wsinfo_valid.json
@@ -13,6 +13,8 @@
             "narrative": "1",
             "data_palette_id": "2",
             "narrative_nice_name": "Test fiesta",
-            "cell_count": "3"
+            "cell_count": "3",
+            "static_narrative_saved": "1597187531703",
+            "static_narrative": "/33192/56/"
         }
 ]

--- a/tests/test_narrative_indexer.py
+++ b/tests/test_narrative_indexer.py
@@ -42,6 +42,9 @@ class TestIndexers(unittest.TestCase):
         for obj in doc['data_objects']:
             self.assertTrue(obj['name'])
             self.assertTrue(obj['obj_type'])
+        # Static narrative fields
+        self.assertEqual(doc['static_narrative_saved'], '1597187531703')
+        self.assertEqual(doc['static_narrative_ref'], '/33500/56/')
 
     def test_temporary_narr(self):
         """Test that temporary narratives get flagged."""

--- a/tests/test_narrative_indexer.py
+++ b/tests/test_narrative_indexer.py
@@ -44,7 +44,7 @@ class TestIndexers(unittest.TestCase):
             self.assertTrue(obj['obj_type'])
         # Static narrative fields
         self.assertEqual(doc['static_narrative_saved'], '1597187531703')
-        self.assertEqual(doc['static_narrative_ref'], '/33500/56/')
+        self.assertEqual(doc['static_narrative_ref'], '/33192/56/')
 
     def test_temporary_narr(self):
         """Test that temporary narratives get flagged."""


### PR DESCRIPTION
Pretty simple update to pull out static narrative info from the workspace metadata, index it, and also add in a couple assertions in the valid narrative test.

Since these are additional fields in the narrative index, we should be able to use the same index without needing a new version.