### PR TITLE
When filtering by type, fetch the object type from the workspace when needed

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -406,6 +406,22 @@ security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
 
 [[package]]
+category = "dev"
+description = "A utility library for mocking out the `requests` Python library."
+name = "responses"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.11.0"
+
+[package.dependencies]
+requests = ">=2.0"
+six = "*"
+urllib3 = ">=1.25.10"
+
+[package.extras]
+tests = ["coverage (>=3.7.1,<6.0.0)", "pytest-cov", "pytest-localserver", "flake8", "pytest (>=4.6,<5.0)", "pytest (>=4.6)"]
+
+[[package]]
 category = "main"
 description = "Python 2 and 3 compatibility utilities"
 name = "six"
@@ -506,7 +522,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "d32e321c46f471ac42eb020aaf6d767d8278496d5ff2a1f7310fe854c77c523f"
+content-hash = "df4403b68b201ab5dfc7ed8936c830ed450a1a32532e3727bae4835b8d5cbd53"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -743,6 +759,10 @@ pyyaml = [
 requests = [
     {file = "requests-2.24.0-py2.py3-none-any.whl", hash = "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"},
     {file = "requests-2.24.0.tar.gz", hash = "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b"},
+]
+responses = [
+    {file = "responses-0.11.0-py2.py3-none-any.whl", hash = "sha256:789e79e8d04b6338b5018d49663e7c8554492ea1469012572aff064cc7bcf4da"},
+    {file = "responses-0.11.0.tar.gz", hash = "sha256:17dcd2facb12182ec353b05b424b2e3f52783f0bf3ad6586e098a11ba75fa666"},
 ]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ mypy = "0.782"
 bandit = "1.6.2"
 flake8 = "3.8.3"
 pytest = "^6.0.1"
+responses = "^0.11.0"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/scripts/docker_deploy
+++ b/scripts/docker_deploy
@@ -1,8 +1,16 @@
 #!/bin/sh
 set -e
-# show the commands we execute
 set -o xtrace
+
 ver=$(cat VERSION)
 export IMAGE_NAME="kbase/index_runner2:$ver"
-sh hooks/build
+echo "Build hook running"
+export BRANCH=${TRAVIS_BRANCH:-`git symbolic-ref --short HEAD`}
+export DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
+export COMMIT=${TRAVIS_COMMIT:-`git rev-parse --short HEAD`}
+
+docker build --build-arg BUILD_DATE=$DATE \
+             --build-arg VCS_REF=$COMMIT \
+             --build-arg BRANCH=$BRANCH \
+             -t ${IMAGE_NAME} .
 docker push $IMAGE_NAME

--- a/src/admin_tools/main.py
+++ b/src/admin_tools/main.py
@@ -1,5 +1,4 @@
 from confluent_kafka import Producer
-from kbase_workspace_client import WorkspaceClient
 from kbase_workspace_client.exceptions import WorkspaceResponseError
 import argparse
 import json
@@ -131,7 +130,6 @@ def _reindex_ws_type(args):
     # - Iterate over all workspaces
     #   - For each workspace, list objects
     #   - For each obj matching args.type, produce a reindex event
-    ws_client = WorkspaceClient(url=config()['kbase_endpoint'], token=config()['ws_token'])
     evtype = 'INDEX_NONEXISTENT'
     if args.overwrite:
         evtype = 'REINDEX'
@@ -139,7 +137,7 @@ def _reindex_ws_type(args):
     for wsid in range(args.start, args.stop + 1):
         wsid = int(wsid)
         try:
-            infos = ws_client.generate_obj_infos(wsid, admin=True)
+            infos = config()['ws_client'].generate_obj_infos(wsid, admin=True)
             for obj_info in infos:
                 obj_type = obj_info[2]
                 if obj_type == args.type:

--- a/src/index_runner/es_indexer.py
+++ b/src/index_runner/es_indexer.py
@@ -5,9 +5,9 @@ Takes workspace kafka event data and generates new Elasticsearch index upates
 import json
 import requests
 import time
-import logging
 from enum import Enum
 
+from src.utils.logger import logger
 from src.utils.config import config
 from src.utils.ws_utils import get_type_pieces
 from src.index_runner.es_indexers.main import index_obj
@@ -23,8 +23,6 @@ _IDX = _PREFIX + ".*"
 _GLOBAL_MAPPINGS = config()['global']['global_mappings']
 _HEADERS = {"Content-Type": "application/json"}
 _MAPPINGS = config()['global']['mappings']
-
-logger = logging.getLogger('IR')
 
 
 def init_indexes():

--- a/src/index_runner/es_indexers/from_sdk.py
+++ b/src/index_runner/es_indexers/from_sdk.py
@@ -1,16 +1,14 @@
-import os
-import uuid
-import json
-import shutil
-import docker
-import requests
-import logging
 from configparser import ConfigParser
+import docker
+import json
+import os
+import requests
+import shutil
+import uuid
 
-from src.utils.config import config
 from src.utils import ws_utils
-
-logger = logging.getLogger('IR')
+from src.utils.config import config
+from src.utils.logger import logger
 
 _DOCKER = docker.from_env()
 _SCRATCH = "/scratch"

--- a/src/index_runner/es_indexers/indexer_utils.py
+++ b/src/index_runner/es_indexers/indexer_utils.py
@@ -1,11 +1,8 @@
-import logging
-from kbase_workspace_client import WorkspaceClient
 from kbase_workspace_client.exceptions import WorkspaceResponseError
 
 from src.utils.config import config
+from src.utils.logger import logger
 from src.utils.ws_utils import get_type_pieces
-
-logger = logging.getLogger('IR')
 
 _REF_DATA_WORKSPACES = []  # type: list
 
@@ -18,9 +15,8 @@ def check_object_deleted(ws_id, obj_id):
     We want to do this because the DELETE event can correspond to more than
     just an object deletion, so we want to make sure the object is deleted
     """
-    ws_client = WorkspaceClient(url=config()['kbase_endpoint'], token=config()['ws_token'])
     try:
-        narr_data_obj_info = ws_client.admin_req("listObjects", {'ids': [ws_id]})
+        narr_data_obj_info = config()['ws_client'].admin_req("listObjects", {'ids': [ws_id]})
     except WorkspaceResponseError as err:
         logger.warning(f"Workspace response error: {err.resp_data}")
         narr_data_obj_info = []
@@ -33,8 +29,7 @@ def is_workspace_public(ws_id):
     """
     Check if a workspace is public, returning bool.
     """
-    ws_client = WorkspaceClient(url=config()['kbase_endpoint'], token=config()['ws_token'])
-    ws_info = ws_client.admin_req('getWorkspaceInfo', {'id': ws_id})
+    ws_info = config()['ws_client'].admin_req('getWorkspaceInfo', {'id': ws_id})
     global_read = ws_info[6]
     return global_read != 'n'
 
@@ -45,9 +40,8 @@ def check_workspace_deleted(ws_id):
     we make sure that the workspace is deleted. This is done by making sure we get an excpetion
     with the word 'delete' in the error body.
     """
-    ws_client = WorkspaceClient(url=config()['kbase_endpoint'], token=config()['ws_token'])
     try:
-        ws_client.admin_req("getWorkspaceInfo", {
+        config()['ws_client'].admin_req("getWorkspaceInfo", {
             'id': ws_id
         })
     except WorkspaceResponseError as err:
@@ -62,9 +56,8 @@ def get_shared_users(ws_id):
     Args:
         ws_id - workspace id of requested workspace object
     """
-    ws_client = WorkspaceClient(url=config()['kbase_endpoint'], token=config()['ws_token'])
     try:
-        obj_perm = ws_client.admin_req("getPermissionsMass", {
+        obj_perm = config()['ws_client'].admin_req("getPermissionsMass", {
             'workspaces': [{'id': ws_id}]
         })['perms'][0]
     except WorkspaceResponseError as err:
@@ -123,9 +116,8 @@ def default_fields(obj_data, ws_info, obj_data_v1):
 
 def handle_id_to_file(handle_id, dest_path):
     """given handle id, download associated file from shock."""
-    ws_client = WorkspaceClient(url=config()['kbase_endpoint'], token=config()['ws_token'])
-    shock_id = ws_client.handle_to_shock(handle_id)
-    ws_client.download_shock_file(shock_id, dest_path)
+    shock_id = config()['ws_client'].handle_to_shock(handle_id)
+    config()['ws_client'].download_shock_file(shock_id, dest_path)
 
 
 def mean(array):

--- a/src/index_runner/es_indexers/main.py
+++ b/src/index_runner/es_indexers/main.py
@@ -1,27 +1,23 @@
 """
 Indexer logic based on type
 """
-import logging
-from kbase_workspace_client import WorkspaceClient
 from kbase_workspace_client.exceptions import WorkspaceResponseError
 
-from src.utils.config import config
-from src.utils import ws_utils
 from src.index_runner.es_indexers import indexer_utils
-from src.index_runner.es_indexers.narrative import index_narrative
-from src.index_runner.es_indexers.reads import index_reads
-from src.index_runner.es_indexers.genome import index_genome
-from src.index_runner.es_indexers.assembly import index_assembly
-from src.index_runner.es_indexers.tree import index_tree
-from src.index_runner.es_indexers.taxon import index_taxon
-from src.index_runner.es_indexers.pangenome import index_pangenome
-from src.index_runner.es_indexers.from_sdk import index_from_sdk
 from src.index_runner.es_indexers.annotated_metagenome_assembly import index_annotated_metagenome_assembly
+from src.index_runner.es_indexers.assembly import index_assembly
+from src.index_runner.es_indexers.from_sdk import index_from_sdk
+from src.index_runner.es_indexers.genome import index_genome
+from src.index_runner.es_indexers.narrative import index_narrative
+from src.index_runner.es_indexers.pangenome import index_pangenome
+from src.index_runner.es_indexers.reads import index_reads
 from src.index_runner.es_indexers.sample_set import index_sample_set
+from src.index_runner.es_indexers.taxon import index_taxon
+from src.index_runner.es_indexers.tree import index_tree
+from src.utils import ws_utils
+from src.utils.config import config
 from src.utils.get_upa_from_msg import get_upa_from_msg_data
-
-logger = logging.getLogger('IR')
-ws_client = WorkspaceClient(url=config()['kbase_endpoint'], token=config()['ws_token'])
+from src.utils.logger import logger
 
 
 def index_obj(obj_data, ws_info, msg_data):
@@ -47,7 +43,7 @@ def index_obj(obj_data, ws_info, msg_data):
     # Get the info of the first object to get the creation date of the object.
     upa = get_upa_from_msg_data(msg_data)
     try:
-        obj_data_v1 = ws_client.admin_req('getObjects', {
+        obj_data_v1 = config()['ws_client'].admin_req('getObjects', {
             'objects': [{'ref': upa + '/1'}],
             'no_data': 1
         })

--- a/src/index_runner/es_indexers/narrative.py
+++ b/src/index_runner/es_indexers/narrative.py
@@ -1,14 +1,10 @@
 import sys
 from bs4 import BeautifulSoup
 from markdown2 import Markdown
-import logging
-from kbase_workspace_client import WorkspaceClient
 
-from src.utils.get_path import get_path
-from src.utils.formatting import ts_to_epoch
 from src.utils.config import config
-
-logger = logging.getLogger('IR')
+from src.utils.formatting import ts_to_epoch
+from src.utils.get_path import get_path
 
 _NAMESPACE = "WS"
 _MARKDOWNER = Markdown()
@@ -143,8 +139,7 @@ def _fetch_objects_in_workspace(ws_id):
     Args:
         ws_id - a workspace id
     """
-    ws_client = WorkspaceClient(url=config()['kbase_endpoint'], token=config()['ws_token'])
-    obj_infos = ws_client.generate_obj_infos(ws_id, admin=True)
+    obj_infos = config()['ws_client'].generate_obj_infos(ws_id, admin=True)
     return [
         {"name": info[1], "obj_type": info[2]}
         for info in obj_infos

--- a/src/index_runner/event_loop.py
+++ b/src/index_runner/event_loop.py
@@ -4,11 +4,11 @@ The event loop for the index runner.
 from confluent_kafka import Consumer, KafkaError
 from typing import Callable, Dict, Any
 import json
-import logging
 import time
 import traceback
 
 from src.utils.config import config
+from src.utils.logger import logger
 
 Message = Dict[str, Any]
 
@@ -21,7 +21,6 @@ def start_loop(
         on_success: Callable[[Message], None] = lambda msg: None,
         on_failure: Callable[[Message, Exception], None] = lambda msg, e: None,
         on_config_update: Callable[[], None] = lambda: None,
-        logger: logging.Logger = logging.getLogger('IR'),
         return_on_empty: bool = False,
         timeout: float = 0.5):
     """

--- a/src/index_runner/main.py
+++ b/src/index_runner/main.py
@@ -3,29 +3,26 @@ Main entrypoint for the app and the Kafka topic consumer.
 Sends work to the es_indexer or the releng_importer.
 Generally handles every message synchronously. Duplicate the service to get more parallelism.
 """
+from kbase_workspace_client.exceptions import WorkspaceResponseError
+import atexit
+import hashlib
 import logging
 import json
-import time
 import os
-import atexit
 import signal
-import hashlib
-from kbase_workspace_client import WorkspaceClient
-from kbase_workspace_client.exceptions import WorkspaceResponseError
+import time
 
 from src.index_runner import event_loop
-import src.utils.kafka as kafka
-from src.utils.logger import init_logger
-import src.utils.es_utils as es_utils
-import src.utils.re_client as re_client
-import src.index_runner.es_indexer as es_indexer
-import src.index_runner.releng_importer as releng_importer
 from src.utils.config import config
+from src.utils.logger import init_logger
+from src.utils.logger import logger
 from src.utils.service_utils import wait_for_dependencies
 from src.utils.ws_utils import get_obj_type
-
-logger = logging.getLogger('IR')
-ws_client = WorkspaceClient(url=config()['kbase_endpoint'], token=config()['ws_token'])
+import src.index_runner.es_indexer as es_indexer
+import src.index_runner.releng_importer as releng_importer
+import src.utils.es_utils as es_utils
+import src.utils.kafka as kafka
+import src.utils.re_client as re_client
 
 
 def _handle_msg(msg):
@@ -53,13 +50,13 @@ def _handle_msg(msg):
         es_indexer.run_indexer(obj, ws_info, msg)
     elif event_type == 'REINDEX_WS' or event_type == 'CLONE_WORKSPACE':
         # Reindex all objects in a workspace, overwriting existing data
-        for objinfo in ws_client.generate_obj_infos(msg['wsid'], admin=True):
+        for objinfo in config()['ws_client'].generate_obj_infos(msg['wsid'], admin=True):
             objid = objinfo[0]
             kafka.produce({'evtype': 'REINDEX', 'wsid': msg['wsid'], 'objid': objid},
                           callback=_delivery_report)
     elif event_type == 'INDEX_NONEXISTENT_WS':
         # Reindex all objects in a workspace without overwriting any existing data
-        for objinfo in ws_client.generate_obj_infos(msg['wsid'], admin=True):
+        for objinfo in config()['ws_client'].generate_obj_infos(msg['wsid'], admin=True):
             objid = objinfo[0]
             kafka.produce({'evtype': 'INDEX_NONEXISTENT', 'wsid': msg['wsid'], 'objid': objid},
                           callback=_delivery_report)
@@ -123,7 +120,7 @@ def _fetch_obj_data(msg):
     if msg.get('ver'):
         obj_ref += f"/{msg['ver']}"
     try:
-        obj_data = ws_client.admin_req('getObjects', {
+        obj_data = config()['ws_client'].admin_req('getObjects', {
             'objects': [{'ref': obj_ref}]
         })
     except WorkspaceResponseError as err:
@@ -146,7 +143,7 @@ def _fetch_ws_info(msg):
     if not msg.get('wsid'):
         raise RuntimeError(f'Cannot get workspace info from msg: {msg}')
     try:
-        ws_info = ws_client.admin_req('getWorkspaceInfo', {
+        ws_info = config()['ws_client'].admin_req('getWorkspaceInfo', {
             'id': msg['wsid']
         })
     except WorkspaceResponseError as err:
@@ -198,8 +195,7 @@ def main():
         _handle_msg,
         on_success=_log_msg_to_elastic,
         on_failure=_log_err_to_es,
-        on_config_update=es_indexer.reload_aliases,
-        logger=logger)
+        on_config_update=es_indexer.reload_aliases)
 
 
 if __name__ == '__main__':

--- a/src/index_runner/main.py
+++ b/src/index_runner/main.py
@@ -22,6 +22,7 @@ import src.index_runner.es_indexer as es_indexer
 import src.index_runner.releng_importer as releng_importer
 from src.utils.config import config
 from src.utils.service_utils import wait_for_dependencies
+from src.utils.ws_utils import get_obj_type
 
 logger = logging.getLogger('IR')
 ws_client = WorkspaceClient(url=config()['kbase_endpoint'], token=config()['ws_token'])
@@ -33,16 +34,16 @@ def _handle_msg(msg):
         msg = f"Missing 'evtype' in event: {msg}"
         logger.error(msg)
         raise RuntimeError(msg)
-    objtype = msg.get('objtype')
+    objtype = get_obj_type(msg)
     if objtype is not None and isinstance(objtype, str) and len(objtype) > 0:
         # Check the type against the configured whitelist or blacklist, if present
         whitelist = config()['allow_types']
         blacklist = config()['skip_types']
         if whitelist is not None and objtype not in whitelist:
-            logger.warning(f"Type {msg['objtype']} is not in ALLOW_TYPES, skipping")
+            logger.warning(f"Type {objtype} is not in ALLOW_TYPES, skipping")
             return
         if blacklist is not None and objtype in blacklist:
-            logger.warning(f"Type {msg['objtype']} is in SKIP_TYPES, skipping")
+            logger.warning(f"Type {objtype} is in SKIP_TYPES, skipping")
             return
     if event_type in ['REINDEX', 'NEW_VERSION', 'COPY_OBJECT', 'RENAME_OBJECT']:
         obj = _fetch_obj_data(msg)

--- a/src/index_runner/releng/del_obj.py
+++ b/src/index_runner/releng/del_obj.py
@@ -1,11 +1,8 @@
 """
 Take object info from the workspace and delete all associated vertices and edges into Arangodb.
 """
-import logging
-
+import src.utils.logger as logger
 import src.utils.re_client as re_client
-
-logger = logging.getLogger('IR')
 
 _OBJ_COLL_NAME = 'ws_object'
 _OBJ_VER_COLL_NAME = 'ws_object_version'

--- a/src/index_runner/releng/genome.py
+++ b/src/index_runner/releng/genome.py
@@ -7,17 +7,14 @@ import time
 from collections import defaultdict as _defaultdict
 import datetime as _datetime
 import itertools as _itertools
-import logging
-from kbase_workspace_client import WorkspaceClient
 
 from src.utils.config import config
+from src.utils.logger import logger
 from src.utils.re_client import stored_query as _stored_query
 from src.utils.re_client import save as _save
 # may want to html encode vs replace with _ to avoid collisions? Seems really improbable
 from src.utils.re_client import clean_key as _clean_key
 from src.utils.re_client import MAX_ADB_INTEGER as _MAX_ADB_INTEGER
-
-logger = logging.getLogger('IR')
 
 _OBJ_VER_COLL = "ws_object_version"
 _TAX_VER_COLL = "ncbi_taxon"
@@ -54,8 +51,7 @@ def _generate_taxon_edge(obj_ver_key, obj_data):
     if 'taxon_ref' not in obj_data['data']:
         logger.info('No taxon ref in object; skipping..')
         return
-    ws_client = WorkspaceClient(url=config()['kbase_endpoint'], token=config()['ws_token'])
-    result = ws_client.admin_req('getObjects', {
+    result = config()['ws_client'].admin_req('getObjects', {
         'objects': [{'ref': obj_data['data']['taxon_ref']}]
     })
     taxonomy_id = result['data'][0]['data']['taxonomy_id']

--- a/src/index_runner/releng/import_obj.py
+++ b/src/index_runner/releng/import_obj.py
@@ -1,21 +1,17 @@
 """
 Take object info from the workspace and import various vertices and edges into Arangodb.
 """
-import logging
-from kbase_workspace_client import WorkspaceClient
-
 from src.index_runner.releng import genome
 from src.utils.ws_utils import get_type_pieces
 from src.utils.re_client import save
 from src.utils.config import config
+from src.utils.logger import logger
 from src.utils.formatting import (
     ts_to_epoch,
     get_method_key_from_prov,
     get_module_key_from_prov,
     sanitize_arangodb_key
 )
-
-logger = logging.getLogger('IR')
 
 # need version specific processors here? Or expect the processor to handle all versions?
 # could also have an includes field to reduce the amount of data fetched from the ws
@@ -55,8 +51,7 @@ def import_object(obj, ws_info):
         # this could use a lot of memory. There's a bunch of code in the workspace for
         # dealing with this situation, but that'd have to be ported to Python and it's pretty
         # complex, so YAGNI for now.
-        ws_client = WorkspaceClient(url=config()['kbase_endpoint'], token=config()['ws_token'])
-        resp = ws_client.admin_req('getObjects', {
+        resp = config()['ws_client'].admin_req('getObjects', {
             'objects': [{
                 'ref': obj_ver_key.replace(':', '/'),
             }]

--- a/src/index_runner/releng_importer.py
+++ b/src/index_runner/releng_importer.py
@@ -3,16 +3,12 @@ Relation Engine (ArangoDB) data importer.
 
 Writes data to arangodb from workspace update events.
 """
-import logging
 import time
 
 from src.utils.config import config
+from src.utils.logger import logger
 from src.index_runner.releng.import_obj import import_object
 from src.index_runner.releng.del_obj import delete_object
-
-logger = logging.getLogger('IR')
-
-# Initialize configuration data
 
 
 def run_importer(obj, ws_info, msg):

--- a/src/index_runner/releng_importer.py
+++ b/src/index_runner/releng_importer.py
@@ -5,7 +5,6 @@ Writes data to arangodb from workspace update events.
 """
 import logging
 import time
-from kbase_workspace_client import WorkspaceClient
 
 from src.utils.config import config
 from src.index_runner.releng.import_obj import import_object
@@ -28,11 +27,10 @@ def delete_obj(msg):
     Delete everything that was created for this object. This is the inverse
     operation of the import_obj action.
     """
-    ws_client = WorkspaceClient(url=config()['kbase_endpoint'], token=config()['ws_token'])
     obj_ref = f"{msg['wsid']}/{msg['objid']}"
     if msg.get("ver"):
         obj_ref += f"/{msg['ver']}"
-    obj_info = ws_client.admin_req('getObjectInfo', {
+    obj_info = config()['ws_client'].admin_req('getObjectInfo', {
         'objects': [{'ref': obj_ref}]
     })['infos'][0]
     delete_object(obj_info)

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1,13 +1,14 @@
+from kbase_workspace_client import WorkspaceClient
 from typing import Optional
 import json
-import logging
 import os
 import requests
 import time
 import urllib.request
 import yaml
 
-logger = logging.getLogger('IR')
+from src.utils.logger import logger
+
 _FETCH_CONFIG_RETRIES = 5
 
 # Defines a process-wide instance of the config.
@@ -74,6 +75,7 @@ class Config:
         for req in reqs:
             if not os.environ.get(req):
                 raise RuntimeError(f'{req} env var is not set.')
+        ws_token = os.environ['WORKSPACE_TOKEN']
         es_host = os.environ.get("ELASTICSEARCH_HOST", 'elasticsearch')
         es_port = os.environ.get("ELASTICSEARCH_PORT", 9200)
         kbase_endpoint = os.environ.get(
@@ -103,7 +105,7 @@ class Config:
             'allow_indices': allow_indices,
             'global': global_config,
             'global_config_url': config_url,
-            'ws_token': os.environ['WORKSPACE_TOKEN'],
+            'ws_token': ws_token,
             'mount_dir': os.environ.get('MOUNT_DIR', os.getcwd()),
             'kbase_endpoint': kbase_endpoint,
             'catalog_url': catalog_url,
@@ -132,6 +134,7 @@ class Config:
             'skip_types': _get_comma_delimited_env('SKIP_TYPES'),
             'allow_types': _get_comma_delimited_env('ALLOW_TYPES'),
             'max_handler_failures': int(os.environ.get('MAX_HANDLER_FAILURES', 3)),
+            'ws_client': WorkspaceClient(url=kbase_endpoint, token=ws_token),
         }
 
     def __getitem__(self, key):

--- a/src/utils/kafka.py
+++ b/src/utils/kafka.py
@@ -2,16 +2,12 @@
 Helper methods for recieving and sending messages from and to Kafka.
 '''
 
-import json
-import logging
-
-from typing import List
-
 from confluent_kafka import Consumer, Producer
+from typing import List
+import json
 
+from src.utils.logger import logger
 from src.utils.config import config
-
-logger = logging.getLogger('src.utils.kafka')
 
 _KAFKA_PRODUCE_RETRIES = 5
 

--- a/src/utils/re_client.py
+++ b/src/utils/re_client.py
@@ -4,7 +4,6 @@ Relation engine API client functions.
 import json
 import re
 import requests
-import logging
 
 from src.utils.config import config
 
@@ -13,8 +12,6 @@ from src.utils.config import config
 MAX_ADB_INTEGER = 2**53 - 1
 
 _ADB_KEY_DISALLOWED_CHARS_REGEX = re.compile(r"[^a-zA-Z0-9_\-:\.@\(\)\+,=;\$!\*'%]")
-
-logger = logging.getLogger('IR')
 
 
 # should this live somewhere else?

--- a/src/utils/service_utils.py
+++ b/src/utils/service_utils.py
@@ -3,10 +3,9 @@ Utilites for dealing with the various services the index runner depends on.
 """
 import time
 import requests
-import logging
-from src.utils.config import config
 
-logger = logging.getLogger('IR')
+from src.utils.config import config
+from src.utils.logger import logger
 
 
 def wait_for_dependencies(elasticsearch=True, re_api=True, timeout=60):

--- a/src/utils/ws_utils.py
+++ b/src/utils/ws_utils.py
@@ -1,3 +1,6 @@
+import responses
+
+from src.utils.config import config
 
 
 def get_type_pieces(type_str):
@@ -9,3 +12,19 @@ def get_type_pieces(type_str):
     (full_name, type_version) = type_str.split('-')
     (type_module, type_name) = full_name.split('.')
     return (type_module, type_name, type_version)
+
+
+def get_obj_type(msg: dict) -> str:
+    """
+    Get the versioned workspace type from a kafka message.
+    """
+    objtype = msg.get('objtype')
+    if isinstance(objtype, str) and len(objtype) > 0:
+        return objtype
+    objid = msg.get('objid')
+    wsid = msg.get('wsid')
+    if objid is not None and wsid is not None:
+        info = config()['ws_client'].admin_req('get_obj_info3', {
+            'objects': [{'ref': f"{objid}/{wsid}"}]
+        })
+        return info['infos'][0][2]

--- a/src/utils/ws_utils.py
+++ b/src/utils/ws_utils.py
@@ -1,4 +1,4 @@
-import responses
+from typing import Optional
 
 from src.utils.config import config
 
@@ -14,7 +14,7 @@ def get_type_pieces(type_str):
     return (type_module, type_name, type_version)
 
 
-def get_obj_type(msg: dict) -> str:
+def get_obj_type(msg: dict) -> Optional[str]:
     """
     Get the versioned workspace type from a kafka message.
     """
@@ -25,6 +25,7 @@ def get_obj_type(msg: dict) -> str:
     wsid = msg.get('wsid')
     if objid is not None and wsid is not None:
         info = config()['ws_client'].admin_req('get_obj_info3', {
-            'objects': [{'ref': f"{objid}/{wsid}"}]
+            'objects': [{'ref': f"{wsid}/{objid}"}]
         })
         return info['infos'][0][2]
+    return None

--- a/tests/unit/index_runner/test_main.py
+++ b/tests/unit/index_runner/test_main.py
@@ -52,6 +52,9 @@ def test_handle_msg_allow_types2():
 
 @responses.activate
 def test_handle_msg_no_objtype():
+    """Valid test path for filtering by type when no `objtype` field is
+    provided, and we fetch the type from the workspace based on the object
+    reference."""
     objtype = "TypeModule.TypeName-1.2"
     # Mock response
     mock_resp = {

--- a/tests/unit/index_runner/test_main.py
+++ b/tests/unit/index_runner/test_main.py
@@ -1,4 +1,5 @@
 import pytest
+import responses
 
 from tests.helpers import set_env
 from src.index_runner.main import _handle_msg
@@ -47,3 +48,33 @@ def test_handle_msg_allow_types2():
         with pytest.raises(RuntimeError) as ctx:
             _handle_msg({'objtype': 'xyz'})
     assert str(ctx.value) == "Missing 'evtype' in event: {'objtype': 'xyz'}"
+
+
+@responses.activate
+def test_handle_msg_no_objtype():
+    objtype = "TypeModule.TypeName-1.2"
+    # Mock response
+    mock_resp = {
+        "version": "1.1",
+        "result": [{
+            "infos": [[
+                1,  # objid
+                "objname",
+                objtype,
+                "2020-08-11T23:12:28+0000",
+                57,  # version
+                "creator_username",
+                33192,  # workspace id
+                "workspace_name",
+                "checksum",
+                24500,  # bytes
+                {},
+            ]],
+            "paths": [["33192/1/57"]]
+        }]
+    }
+    responses.add(responses.POST, config()['workspace_url'], json=mock_resp)
+    with set_env(SKIP_TYPES=objtype):
+        config(force_reload=True)
+        res = _handle_msg({'objid': 1, 'wsid': 3000, 'evtype': 'x'})
+    assert res is None


### PR DESCRIPTION
Before, I was just pulling the object type from the message's `objtype` field, but realized that some events like COPY_OBJECT don't provide the object type, only the ref. For those, I fetch the type using get_object_info3

Also added a test with a mock response.

Also added a couple misc fixes